### PR TITLE
Explicitly ask user to download either audio or video

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -288,16 +288,14 @@ def main():
                 console.print("\n[red]Operation cancelled by user.[/red]")
                 sys.exit(0)
         url = urls[0]
-        use_video = not guess_is_music(url)
-        pick_audio = False
-        fmt = "mp3"
-        if use_video:
-            pick_audio = Confirm.ask("Download as audio (mp3/m4a/flac)?", default=False)
-            if pick_audio:
-                fmt = pick_audio_format()
-        else:
+        choice = Prompt.ask("Download as", choices=["video", "audio"], default="video")
+        if choice == "audio":
             fmt = pick_audio_format()
-        mode = "audio" if guess_is_music(url) or pick_audio else "video"
+            mode = "audio"
+        else:
+            mode = "video"
+            fmt = "mp4"
+
         folder = Prompt.ask("Output folder", default=last_output_folder)
         if not os.path.exists(folder):
             os.makedirs(folder)

--- a/yt_downloader_config.json
+++ b/yt_downloader_config.json
@@ -1,1 +1,0 @@
-{"last_output_folder": "Downloads"}

--- a/yt_downloader_config.json
+++ b/yt_downloader_config.json
@@ -1,0 +1,1 @@
+{"last_output_folder": "Downloads"}


### PR DESCRIPTION
I updated the downloader to explicitly ask the user to download either audio or video.

This PR improves the download mode selection prompt.

Previously, the script asked only:

**Download as audio (mp3/m4a/flac)? [y/n] (n):**

which made it appear that audio was the only supported option.

With this change, the prompt is:

**Download as [video/audio] (video):**

-If audio is chosen, the user is asked to pick mp3/m4a/flac.

-If video is chosen, the app downloads an mp4 video as already implemented.

This makes the app logic align with the README and makes video mode discoverable for new users.